### PR TITLE
adding a couple more tests and user guards for modifying rental posts

### DIFF
--- a/app/controllers/rentals_controller.rb
+++ b/app/controllers/rentals_controller.rb
@@ -1,6 +1,7 @@
 class RentalsController < ApplicationController
   before_action :set_rental, only: [:show, :edit, :update, :destroy]
   before_action :logged_in_user, only: [:new, :create, :edit, :update, :destroy]
+  before_action :correct_user, only: [:edit, :update, :destroy]
 
   # GET /rentals
   # GET /rentals.json
@@ -13,6 +14,7 @@ class RentalsController < ApplicationController
   # GET /rentals/1
   # GET /rentals/1.json
   def show
+    @rental = Rental.find(params[:id])
   end
 
   # GET /rentals/new
@@ -92,6 +94,16 @@ class RentalsController < ApplicationController
     unless logged_in?
       flash[:danger] = "Please log in before accessing rental posts."
       redirect_to login_url
+    end
+  end
+
+  # confirms the correct user
+  def correct_user
+    @rental = Rental.find(params[:id])
+    @user = User.find(@rental.owner_id)
+    unless current_user?(@user)
+      flash[:danger] = "You are not the owner of this rental post."
+      redirect_to(@rental)
     end
   end
 end

--- a/test/controllers/rentals_controller_test.rb
+++ b/test/controllers/rentals_controller_test.rb
@@ -88,4 +88,27 @@ class RentalsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to login_url
   end
 
+  test 'should redirect when not owner of rentalpost EDIT' do
+    log_in_as(@user2, password: "foobar")
+    get edit_rental_url(@rental)
+    assert_not flash.empty?
+    assert_redirected_to @rental
+  end
+
+  test 'should redirect when not owner of rentalpost UPDATE' do
+    log_in_as(@user2, password: "foobar")
+    patch rental_url(@rental), params: { rental: { owner_id: @rental.owner_id, renter_id: @rental.renter_id, car_id: @rental.car_id,
+                                                   start_location: @rental.start_location, end_location: @rental.end_location, start_time: @rental.start_time, end_time: @rental.end_time,
+                                                   price: @rental.price, status: @rental.status, terms: @rental.terms } }
+    assert_not flash.empty?
+    assert_redirected_to @rental
+  end
+
+  test 'should redirect when not owner of rentalpost DELETE' do
+    log_in_as(@user2, password: "foobar")
+    delete rental_url(@rental)
+    assert_not flash.empty?
+    assert_redirected_to @rental
+  end
+
 end


### PR DESCRIPTION
Users must be logged in AND be the owner of a rental post to edit and/or delete it.