### PR TITLE
Better license plate validation (PR #85)

### DIFF
--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -1,10 +1,17 @@
 class Car < ApplicationRecord
+    before_save {self.plate_number = plate_number.upcase}
     belongs_to :user
     has_many :taggings
     has_many :tags, through: :taggings
 
-    PLATE_REGEX = /\A\d{1}[a-z]{3}\d{3}\z/i
-    validates :plate_number, presence: true, length: {is: 7}, format: {with: PLATE_REGEX}
+    # http://guides.rubyonrails.org/active_record_validations.html#validates-each
+    validates_each :plate_number do |record, attr, value|
+        # puts "Checking plate number #{value}"
+        record.errors.add(attr, 'must have length 2 to 7') if not (2 <= value.length and value.length <= 7)
+        record.errors.add(attr, 'must be only letters, numbers, or spaces') if not value.match? /\A[a-z0-9 ]+\z/i
+        record.errors.add(attr, 'must have at least two non-space characters') if not value.match? /\A.*[a-z0-9].*[a-z0-9].*\z/i
+      end
+    
     validates :year, presence: true, numericality: {greater_than: 1900}
 
     def all_tags=(names)

--- a/test/integration/car_flows_test.rb
+++ b/test/integration/car_flows_test.rb
@@ -49,7 +49,7 @@ class CarFlowsTest < ActionDispatch::IntegrationTest
     assert_equal 'prius', mycar.model
     assert_equal 2004, mycar.year
     assert_equal 'white', mycar.color
-    assert_equal '3bne098', mycar.plate_number
+    assert_equal '3BNE098', mycar.plate_number
 
     # delete the car
     assert_difference 'Car.count', -1 do

--- a/test/models/car_test.rb
+++ b/test/models/car_test.rb
@@ -9,14 +9,38 @@ class CarTest < ActiveSupport::TestCase
   end
 
 
-  test "license plate has form DLLLDDD, all digs not allowed" do
-    @car.plate_number = "1234567"
-    assert_not @car.valid?
+  test "license plate len 2 ok" do
+    @car.plate_number = "12"
+    assert @car.valid?
   end
 
-  test "license plate has form DLLLDDD" do
+  test "license plate len 7 ok" do
+    @car.plate_number = "1234567"
+    assert @car.valid?
+  end
+
+  test "license plate len 8 not ok" do
+    @car.plate_number = "12345678"
+    assert @car.invalid?
+  end
+
+  test "license plate len 1 not ok" do
+    @car.plate_number = "1"
+    assert @car.invalid?
+  end
+
+  test "license plate has illegal char" do
+    @car.plate_number = "6we!123"
+    assert @car.invalid?
+  end
+
+  test "license plate has only let, num, spaces" do
     @car.plate_number = "6wer123"
-    puts "Plate: #{@car.plate_number}, valid?: #{@car.valid?}"
+    assert @car.valid?
+  end
+
+  test "license plate has at least 2 non-sp characters" do
+    @car.plate_number = "1     2"
     assert @car.valid?
   end
 


### PR DESCRIPTION
This PR addresses issue #85 . 

Added license plate validations & tests.

Description (if needed):
- license plates btwn 2 and 7 chars long
- only letter, digit, space allowed
- at least 2 non-space chars
- stores upper-case