### PR TITLE
the `match?` syntax does not work with my version of ruby (2.3) so I …

### DIFF
--- a/app/models/car.rb
+++ b/app/models/car.rb
@@ -1,31 +1,31 @@
 class Car < ApplicationRecord
-    before_save {self.plate_number = plate_number.upcase}
-    belongs_to :user
-    has_many :taggings
-    has_many :tags, through: :taggings
+  before_save { self.plate_number = plate_number.upcase }
+  belongs_to :user
+  has_many :taggings
+  has_many :tags, through: :taggings
 
-    # http://guides.rubyonrails.org/active_record_validations.html#validates-each
-    validates_each :plate_number do |record, attr, value|
-        # puts "Checking plate number #{value}"
-        record.errors.add(attr, 'must have length 2 to 7') if not (2 <= value.length and value.length <= 7)
-        record.errors.add(attr, 'must be only letters, numbers, or spaces') if not value.match? /\A[a-z0-9 ]+\z/i
-        record.errors.add(attr, 'must have at least two non-space characters') if not value.match? /\A.*[a-z0-9].*[a-z0-9].*\z/i
-      end
-    
-    validates :year, presence: true, numericality: {greater_than: 1900}
+  # http://guides.rubyonrails.org/active_record_validations.html#validates-each
+  validates_each :plate_number do |record, attr, value|
+    # puts "Checking plate number #{value}"
+    record.errors.add(attr, 'must have length 2 to 7') unless (value.length >= 2) && (value.length <= 7)
+    record.errors.add(attr, 'must be only letters, numbers, or spaces') unless value.match /\A[a-z0-9 ]+\z/i
+    record.errors.add(attr, 'must have at least two non-space characters') unless value.match /\A.*[a-z0-9].*[a-z0-9].*\z/i
+  end
 
-    def all_tags=(names)
-      self.tags = names.split(",").map do |name|
-          Tag.where(name: name.strip).first_or_create!
-      end
+  validates :year, presence: true, numericality: { greater_than: 1900 }
+
+  def all_tags=(names)
+    self.tags = names.split(',').map do |name|
+      Tag.where(name: name.strip).first_or_create!
     end
+  end
 
-    def all_tags
-      self.tags.map(&:name).join(", ")
-    end
+  def all_tags
+    tags.map(&:name).join(', ')
+  end
 
-    def self.tagged_with(name)
-      name = name.downcase
-      Tag.find_by_name!(name).cars
-    end
+  def self.tagged_with(name)
+    name = name.downcase
+    Tag.find_by_name!(name).cars
+  end
 end


### PR DESCRIPTION
…switched it back to just `match` which passes the tests. turns out upgrading ruby (to ver 2.4 which introduces `match?`) on fedora 25 is a pain :( so I just used the older syntax instead.

I hope this is not a problem; its just ruby being annoying :frowning_face: The existing tests still work, so I think my changes won't break anything :crossed_fingers: 

@justinpearson This modifies your code from bec94ef701ec4511e1ed3e9c10bbf3fde01284be so I'd just like to check before pushing this to master.