### PR TITLE
added button to promote user to admin

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
 class UsersController < ApplicationController
-  before_action :set_user, only: [:cars, :history, :settings]
+  before_action :set_user, only: [:cars, :history, :settings, :promote]
   before_action :logged_in_user, only: [:edit, :update]
   before_action :correct_user, only: [:edit, :update]
   before_action :set_progress, only: [:overview, :rentals]
@@ -97,6 +97,23 @@ class UsersController < ApplicationController
     @cars_count = Car.where(user_id: @user.id).length
     @rides_sold_count = Rental.where(owner_id: @user.id).length
     @rides_bought_count = Rental.where(renter_id: @user.id).length
+  end
+
+  # PATCH /users/1/promote
+  def promote
+    @user.update_attribute(:admin, true)
+
+    Log.create!(
+      user_id: session[:user_id], 
+      action: 0, 
+      content: 'Promoted '+@user.username+' to admin' )
+    Log.create!(
+      user_id: @user.id, 
+      action: 0, 
+      content: 'Promoted to admin by '+User.find(session[:user_id]).username )
+
+    flash[:success] = 'You have successfully promoted this user to admin'
+    redirect_to overview_user_path(@user.id)
   end
 
   private

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -21,4 +21,12 @@ module SessionsHelper
     session.delete(:user_id)
     @current_user = nil
   end
+
+  def current_admin?
+    if current_user
+      return current_user.admin
+    else
+      return false
+    end
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -29,7 +29,7 @@
       <%= yield %>
     </main>
     <footer>
-      <% if User.find_by(id: session[:user_id]) && User.find_by(id: session[:user_id]).admin == true %>
+      <% if current_admin? %>
         <%= render 'layouts/debug' %>
       <% end %>
       <%= render 'layouts/footer' %>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -13,6 +13,8 @@
         <div class="col-auto ml-auto">
           <% if session[:user_id] == user.id %>
             <%= link_to icon('pencil')+"Edit", edit_user_path, class: 'btn btn-outline-success', role: 'button' %>
+          <% elsif session[:user_id] != user.id && User.find(session[:user_id]).admin == true && user.admin == false %>
+            <%= link_to 'Promote to Admin', promote_user_path, method: :patch, class: 'btn btn-outline-danger', role: 'button' %>
           <% end %>
         </div>
       </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -11,9 +11,11 @@
           <p class="list-group-item mb-2"><%= icon('clock-o', class: 'fa-fw') %>Last logged in on <%= user.logged_in_at.strftime("%A, %B %-d") %> at <%= user.logged_in_at.strftime("%l:%M %p") %></p>
         </div>
         <div class="col-auto ml-auto">
-          <% if session[:user_id] == user.id %>
+          <!-- If it's your own profile, you can edit it. -->
+          <% if current_user?(user) %> 
             <%= link_to icon('pencil')+"Edit", edit_user_path, class: 'btn btn-outline-success', role: 'button' %>
-          <% elsif session[:user_id] != user.id && User.find_by(id: session[:user_id]).admin == true && user.admin == false %>
+          <!-- Else, if you're an admin and 'user' isn't, you can promote him. -->
+          <% elsif current_admin? and not user.admin %>
             <%= link_to 'Promote to Admin', promote_user_path, method: :patch, class: 'btn btn-outline-danger', role: 'button' %>
           <% end %>
         </div>

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -13,7 +13,7 @@
         <div class="col-auto ml-auto">
           <% if session[:user_id] == user.id %>
             <%= link_to icon('pencil')+"Edit", edit_user_path, class: 'btn btn-outline-success', role: 'button' %>
-          <% elsif session[:user_id] != user.id && User.find(session[:user_id]).admin == true && user.admin == false %>
+          <% elsif session[:user_id] != user.id && User.find_by(id: session[:user_id]).admin == true && user.admin == false %>
             <%= link_to 'Promote to Admin', promote_user_path, method: :patch, class: 'btn btn-outline-danger', role: 'button' %>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
       get 'cars'
       get 'history'
       get 'settings'
+      patch 'promote'
     end
   end
   get 'signup', to: 'users#new'

--- a/test/controllers/rentals_controller_test.rb
+++ b/test/controllers/rentals_controller_test.rb
@@ -64,7 +64,7 @@ class RentalsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to rental_url(Rental.last)
   end
 
-  test "should show rental" do
+  test "should show rental (as guest)" do
     get rental_url(@rental)
     assert_response :success
   end


### PR DESCRIPTION
This PR addresses issue #70 . 

When an admin user views another user's profile who isn't an admin a button will be there allowing them to promote the user to admin. As a result, a log will be created in each one's history about the event
